### PR TITLE
FIx para los separadores de parámetros en las URLs

### DIFF
--- a/deeplinks-en-explore.md
+++ b/deeplinks-en-explore.md
@@ -10,19 +10,19 @@ Esta es la lista de deep links \(enlaces\) para llevar al usuario al contenido d
 
 **Accesorios**
 
-`https://appwebview.movistar.es/explore?refresh=true?categoryID=accesory` 
+`https://appwebview.movistar.es/explore?refresh=true&categoryID=accesory` 
 
 **Paquetes**
 
-`https://appwebview.movistar.es/explore?refresh=true?categoryID=bundle`
+`https://appwebview.movistar.es/explore?refresh=true&categoryID=bundle`
 
 **Dispositivos**
 
-`https://appwebview.movistar.es/explore?refresh=true?categoryID=device`
+`https://appwebview.movistar.es/explore?refresh=true&categoryID=device`
 
 **Fidelización**
 
-`https://appwebview.movistar.es/explore?refresh=true?categoryID=loyalty`
+`https://appwebview.movistar.es/explore?refresh=true&categoryID=loyalty`
 
 **Promociones**
 
@@ -30,15 +30,15 @@ Esta es la lista de deep links \(enlaces\) para llevar al usuario al contenido d
 
 **Planes**
 
-`https://appwebview.movistar.es/explore?refresh=true?categoryID=plan`
+`https://appwebview.movistar.es/explore?refresh=true&categoryID=plan`
 
 **Servicios**
 
-`https://appwebview.movistar.es/explore?refresh=true?categoryID=value_added_service` 
+`https://appwebview.movistar.es/explore?refresh=true&categoryID=value_added_service` 
 
 **Televisión**
 
-`https://appwebview.movistar.es/explore?refresh=true?categoryID=tv` 
+`https://appwebview.movistar.es/explore?refresh=true&categoryID=tv` 
 
 {% hint style="warning" %}
 Ten en cuenta que esta URL varía en función de la OB. Asegúrate de estar usando la correcta 😉 


### PR DESCRIPTION
Hola. Icíar. he hecho algunos cambios porque había confusión con los separadores de los parámetros de las URLS. He cambiado ? por &